### PR TITLE
Have FlashHash inherit from Hash

### DIFF
--- a/lib/rails_4_session_flash_backport/rails2/flash_hash.rb
+++ b/lib/rails_4_session_flash_backport/rails2/flash_hash.rb
@@ -73,10 +73,7 @@ end
 # This magic here allows us to unmarshal a Rails 3.2 ActionDispatch::Flash::FlashHash
 module ActionDispatch
   class Flash
-    class FlashHash
-      def self._load(args)
-        {}
-      end
+    class FlashHash < Hash
     end
   end
 end


### PR DESCRIPTION
After a long pairing session with Brandon, we figured out why we were getting the marshal load errors in prod.

ArgumentError: dump format error (user class)

The reason was that FlashHash was not actually a hash, but inherits from Hash in Rails 3.  Thus, it blew up in rails 2.

My patch patches up this library to ensure that FlashHash gets defined as a subclass of Hash.
